### PR TITLE
Fix incorrect SLURM_VERSION for buildSlurmForRedHatBased

### DIFF
--- a/slurm_install.sh
+++ b/slurm_install.sh
@@ -610,7 +610,7 @@ buildSlurmForRedHatBased()
 	mkdir -p slurm-tmp
 	cd slurm-tmp
 
-	if [ "$VER" == "" ]; then
+	if [ "$SLURM_VERSION" == "" ]; then
 	    export SLURM_VERSION=22.05.9
 	fi
 	wget --no-check-certificate https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2


### PR DESCRIPTION
Missed a part of modification from 9b31f3374a06848ef315b29cc261714e4b9ad06c